### PR TITLE
Feat: 대략적인 메인페이지 구성

### DIFF
--- a/components/MainLayout/mainFooter.tsx
+++ b/components/MainLayout/mainFooter.tsx
@@ -1,0 +1,28 @@
+import Image from 'next/image';
+import styled from 'styled-components';
+
+function MainFooter() {
+  return (
+    <FooterWrapper>
+      <FooterContentWrapper>
+        <Image src='/assets/images/metaRabbit.png' width={80} height={80} />
+        <FooterContent>사업자 내용</FooterContent>
+      </FooterContentWrapper>
+    </FooterWrapper>
+  );
+}
+
+export default MainFooter;
+
+const FooterWrapper = styled.footer`
+  background-color: gray;
+  height: 200px;
+  border-radius: 20px 20px 0px 0px;
+`;
+const FooterContentWrapper = styled.div`
+  padding: 20px;
+  display: flex;
+`;
+const FooterContent = styled.div`
+  padding-left: 100px;
+`;

--- a/components/MainLayout/mainHeader.tsx
+++ b/components/MainLayout/mainHeader.tsx
@@ -8,6 +8,10 @@ function MainHeader() {
       <Link href='/'>
         <Image src='/assets/images/metaRabbit.png' width={50} height={50} />
       </Link>
+      <SearchWrapper>
+        <SearchInput />
+        <SearchBtn>search</SearchBtn>
+      </SearchWrapper>
       <MenuWrapper>
         <Link href='/menu1'>menu1</Link>
         <Link href='/menu2'>menu2</Link>
@@ -19,7 +23,7 @@ function MainHeader() {
 const Header = styled.header`
   display: flex;
   width: 100%;
-  justify-content: space-between;
+  justify-content: space-around;
   align-items: center;
   background-color: skyblue;
   margin-bottom: 20px;
@@ -31,9 +35,19 @@ const Header = styled.header`
 `;
 const MenuWrapper = styled.div`
   display: flex;
-  justify-content: space-between;
-  ainer-align: center;
-  width: 100%;
+  justify-content: space-around;
+  align-items: center;
+  width: 30%;
   margin: 15px;
 `;
+const SearchWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-left: 100px;
+  width: 50%;
+`;
+const SearchInput = styled.input`
+  width: 100%;
+`;
+const SearchBtn = styled.button``;
 export default MainHeader;

--- a/components/MainLayout/mainHeader.tsx
+++ b/components/MainLayout/mainHeader.tsx
@@ -25,6 +25,9 @@ const Header = styled.header`
   margin-bottom: 20px;
   border-radius: 0px 0px 20px 20px;
   padding: 20px;
+  position: fixed;
+  top: 0;
+  z-index: 1;
 `;
 const MenuWrapper = styled.div`
   display: flex;

--- a/components/MainLayout/mainHeader.tsx
+++ b/components/MainLayout/mainHeader.tsx
@@ -1,0 +1,36 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import styled from 'styled-components';
+
+function MainHeader() {
+  return (
+    <Header>
+      <Link href='/'>
+        <Image src='/assets/images/metaRabbit.png' width={50} height={50} />
+      </Link>
+      <MenuWrapper>
+        <Link href='/menu1'>menu1</Link>
+        <Link href='/menu2'>menu2</Link>
+        <Link href='/menu3'>menu3</Link>
+      </MenuWrapper>
+    </Header>
+  );
+}
+const Header = styled.header`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  background-color: skyblue;
+  margin-bottom: 20px;
+  border-radius: 0px 0px 20px 20px;
+  padding: 20px;
+`;
+const MenuWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  ainer-align: center;
+  width: 100%;
+  margin: 15px;
+`;
+export default MainHeader;

--- a/components/MainLayout/mainLayout.tsx
+++ b/components/MainLayout/mainLayout.tsx
@@ -15,5 +15,6 @@ function MainLayout(props: any) {
 export default MainLayout;
 
 const Main = styled.main`
+  margin-top: 100px;
   height: 100vh;
 `;

--- a/components/MainLayout/mainLayout.tsx
+++ b/components/MainLayout/mainLayout.tsx
@@ -1,12 +1,19 @@
 import { Fragment } from 'react';
+import styled from 'styled-components';
+import MainFooter from './mainFooter';
 import MainHeader from './mainHeader';
 
 function MainLayout(props: any) {
   return (
     <Fragment>
       <MainHeader />
-      <main>{props.children}</main>
+      <Main>{props.children}</Main>
+      <MainFooter />
     </Fragment>
   );
 }
 export default MainLayout;
+
+const Main = styled.main`
+  height: 100vh;
+`;

--- a/components/MainLayout/mainLayout.tsx
+++ b/components/MainLayout/mainLayout.tsx
@@ -1,0 +1,12 @@
+import { Fragment } from 'react';
+import MainHeader from './mainHeader';
+
+function MainLayout(props: any) {
+  return (
+    <Fragment>
+      <MainHeader />
+      <main>{props.children}</main>
+    </Fragment>
+  );
+}
+export default MainLayout;

--- a/components/products/productItem.tsx
+++ b/components/products/productItem.tsx
@@ -1,0 +1,19 @@
+import Image from 'next/image';
+import styled from 'styled-components';
+
+function ProductItem(props: any) {
+  const { imgPath } = props;
+  return (
+    <ProductItemWrapper>
+      <Image src={imgPath} width={100} height={100} />
+      <ItemWrapper>
+        <div>이름</div>
+        <div>간단 설명</div>
+      </ItemWrapper>
+    </ProductItemWrapper>
+  );
+}
+export default ProductItem;
+
+const ProductItemWrapper = styled.div``;
+const ItemWrapper = styled.div``;

--- a/components/products/productList.tsx
+++ b/components/products/productList.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import ProductItem from './productItem';
+
+function ProductList(props: any) {
+  const { productList, title } = props;
+  return (
+    <ProductsWrapper>
+      <Title>{title}</Title>
+      <ItemWrapper>
+        {productList.map((product: any) => (
+          <ProductItem imgPath={product.imgPath} />
+        ))}
+      </ItemWrapper>
+    </ProductsWrapper>
+  );
+}
+export default ProductList;
+
+const ProductsWrapper = styled.div`
+  margin: 20px;
+`;
+const ItemWrapper = styled.div`
+  display: flex;
+`;
+const Title = styled.div`
+  font-size: 30px;
+  margin-bottom: 10px;
+`;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,13 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
+import MainLayout from '../components/MainLayout/mainLayout';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <MainLayout>
+      <Component {...pageProps} />
+    </MainLayout>
+  );
 }
 
 export default MyApp;

--- a/pages/api/products.ts
+++ b/pages/api/products.ts
@@ -2,7 +2,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export interface ProductResponse {
-  result: Array<EachProduct>;
+  productList: Array<EachProduct>;
 }
 export interface EachProduct {
   productName: string;
@@ -11,7 +11,7 @@ export interface EachProduct {
 
 export default function handler(req: NextApiRequest, res: NextApiResponse<ProductResponse>) {
   res.status(200).json({
-    result: [
+    productList: [
       { productName: 'clothes1', imgPath: '/assets/images/metaRabbit.png' },
       { productName: 'hat', imgPath: '/assets/images/testImg2.png' },
     ],

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,8 @@ interface ProductResponseWrapper {
   productList: ProductResponse;
 }
 
-function HomePage(props: ProductResponseWrapper) {
+//TODO: props타입을 설정해야함
+function HomePage(props: any) {
   const { productList } = props;
   return (
     <BodyWrapper>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,30 @@
-import Link from 'next/link';
+import styled from 'styled-components';
+import ProductList from '../components/products/productList';
+import { ProductResponse } from './api/products';
 
-function HomePage() {
-  return <Link href='/products'>전체 물품 리스트</Link>;
+interface ProductResponseWrapper {
+  productList: ProductResponse;
+}
+
+function HomePage(props: ProductResponseWrapper) {
+  const { productList } = props;
+  return (
+    <BodyWrapper>
+      <ProductList productList={productList} title='금일 hot' />
+      <ProductList productList={productList} title='weekly hot items' />
+    </BodyWrapper>
+  );
+}
+export async function getStaticProps() {
+  const result = await fetch('http://localhost:3000/api/products');
+  const { productList } = await result.json();
+
+  return {
+    props: {
+      productList,
+    },
+  };
 }
 export default HomePage;
+
+const BodyWrapper = styled.div``;

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -1,28 +1,5 @@
-import { ProductResponse } from '../api/products';
-import Image from 'next/image';
-
-interface ProductResponseWrapper {
-  data: ProductResponse;
-}
-const ProductPage = ({ data }: ProductResponseWrapper) => {
-  return (
-    <div>
-      {data.result.map((val: any) => (
-        <div key={val.productName}>
-          <Image src={`${val.imgPath}`} width={300} height={300} />
-          <div>{val.productName}</div>
-        </div>
-      ))}
-    </div>
-  );
+const ProductPage = (props: any) => {
+  return;
 };
-export async function getStaticProps() {
-  const result = await fetch('http://localhost:3000/api/products');
-  const data: ProductResponse = await result.json();
-  return {
-    props: {
-      data,
-    },
-  };
-}
+
 export default ProductPage;

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -3,22 +3,24 @@ import { render, screen } from '@testing-library/react';
 import HomePage from '../pages/index';
 import ProductPage from '../pages/products';
 
-it('홈페이지를 보여준다.', () => {
-  render(<HomePage />);
-  const element = screen.getByRole('link', {
-    name: '전체 물품 리스트',
-  });
-  expect(element).toBeInTheDocument();
+const props = {
+  productList: [
+    { productName: 'clothes1', imgPath: '/assets/images/metaRabbit.png' },
+    { productName: 'hat', imgPath: '/assets/images/testImg2.png' },
+  ],
+};
+
+it('메인 페이지를 보여준다.', () => {
+  render(<HomePage {...props} />);
+  const todayHotElement = screen.getByText('금일 hot');
+  expect(todayHotElement).toBeInTheDocument();
+
+  const weeklyHotElement = screen.getByText('weekly hot items');
+  expect(weeklyHotElement).toBeInTheDocument();
 });
 
 it('Product Page를 보여준다.', () => {
-  const productList = {
-    result: [
-      { productName: 'clothes1', imgPath: '/assets/images/metaRabbit.png' },
-      { productName: 'hat', imgPath: '/assets/images/testImg2.png' },
-    ],
-  };
-  render(<ProductPage data={productList} />);
-  const element = screen.getAllByRole('img');
-  expect(element).toHaveLength(2);
+  // render(<ProductPage data={productList} />);
+  // const element = screen.getAllByRole('img');
+  // expect(element).toHaveLength(2);
 });


### PR DESCRIPTION
## 메인 페이지 구성
- 헤더 추가  
    - 로고, 검색바, 메뉴 추가
    - 헤더 고정 
- 상품 컴포넌트 추가
- footer추가
    - 로고 및 사업자 설명란 추가
 

## 화면 캡쳐

![image](https://user-images.githubusercontent.com/67806982/206213738-d3828e2d-773a-4b94-a523-4740ce0d34f9.png)

## 해야할 것

- props 타입 추가 및 물품 상세 페이지 추가